### PR TITLE
Adjust JavaDoc @author format

### DIFF
--- a/build-tools/src/main/resources/build-tools/checkstyle.xml
+++ b/build-tools/src/main/resources/build-tools/checkstyle.xml
@@ -78,7 +78,7 @@
 		<module name="JavadocType">
 			<property name="scope" value="package"/>
 			<property name="authorFormat"
-			          value="[A-Z][a-z\u00E0-\u00FC]+\s[A-Z][a-z\u00E0-\u00FC]+\s\(\b[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}\b\)"/>
+			          value="[-A-Za-z\u00C0-\u00F6\u00F8-\u00FF]+\s[-A-Za-z\u00C0-\u00F6\u00F8-\u00FF]+\s\(\b[a-z0-9._%+-]+@[a-z0-^9.-]+\.[a-z]{2,4}\b\)"/>
 			<property name="versionFormat" value="\$Id\$"/>
 		</module>
 		<module name="JavadocMethod">

--- a/takes/src/test/java/de/aice/roster/web/ApplicationTest.java
+++ b/takes/src/test/java/de/aice/roster/web/ApplicationTest.java
@@ -10,7 +10,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public final class ApplicationTest {
 
@@ -49,6 +51,10 @@ public final class ApplicationTest {
 			assertThat(e).hasCauseExactlyInstanceOf(ConnectException.class);
 			assertThat(e.getCause()).hasMessage("Connection refused");
 		}
+	}
+
+	private String localHostAddress() {
+		return String.format("http://localhost:%s/", this.properties.port());
 	}
 
 }


### PR DESCRIPTION
The JavaDoc @author format must be adjusted as it is not supporting some
accented characters like 'é'. The ApplicationTest in the 'takes' module
needs to be adjusted as it does not work in Codeship build environment.

This pr will resolve #2 